### PR TITLE
feat(ci/containers): only run dockers CI when other CI is completed

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,16 +1,10 @@
 name: Containers CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "**.py"
-      - ".devcontainer/Containerfile"
-  pull_request:
-    branches: [main]
-    paths:
-      - "**.py"
-      - ".devcontainer/Containerfile"
+  workflow_run:
+    workflows: [Build and Tests]
+    types:
+      - completed
   release:
     types: [created]
 


### PR DESCRIPTION
This PR aims to update the containers CI such that it only runs if the "Build and Tests" workflow runs successfully.